### PR TITLE
test(framework): dynamically export kubeconfig to support short-validity kubeconfig files

### DIFF
--- a/mk/run.mk
+++ b/mk/run.mk
@@ -56,6 +56,7 @@ cleanup-kubernetes:
 
 .PHONY: run
 run: fetch-product deploy-kubernetes
+	$(eval ENV_NAME=$(shell kubectl --kubeconfig=$(TOP)/build/kubernetes/cluster.config config view -o jsonpath='{.clusters[0].name}'))
 	mkdir -p $(TOP)/build/debug-output
-	$(E2E_ENV_VARS) KUBECONFIG=$(TOP)/build/kubernetes/cluster.config $(GINKGO) -v --timeout=4h --json-report=raw-report.json ./test/...
+	$(E2E_ENV_VARS) SMOKE_ENV_TYPE=$(SMOKE_ENV_TYPE) SMOKE_ENV_NAME=$(ENV_NAME) $(GINKGO) -v --timeout=4h --json-report=raw-report.json ./test/...
 	$(MAKE) cleanup-kubernetes


### PR DESCRIPTION
Dynamically export kubeconfig to support short-validity kubeconfig files.

Kubeconfig generated from AWS EKS clusters are only valid for 15 mins, and this is not enough to run our test suite. So we periodically export the kubeconfig during the test running. 

I checked our test framework and I can confirm that our test code will always invoke the `kubectl` command to interact with the cluster, so by updating the kubeconfig file dynamically, we get the compatiability to the short-validity kubeconfig files.


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
* Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
* Yes