### PR TITLE
chore(workflow): enable eks in CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        envPlatform: ${{ fromJSON( github.event_name == 'workflow_dispatch' && '["kind", "gke"]' || '["kind"]' ) }}
+        envPlatform: ${{ fromJSON( github.event_name == 'workflow_dispatch' && '["kind", "gke", "eks"]' || '["kind"]' ) }}
       fail-fast: false
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-test') }}
     steps:
@@ -62,7 +62,11 @@ jobs:
           GOOGLE_PROJECT: ${{ secrets.GOOGLE_PROJECT }}
           GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-        if: ${{ matrix.envPlatform != 'gke' || env.GOOGLE_PROJECT != '' }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        if: ${{ matrix.envPlatform == 'kind' || (matrix.envPlatform == 'gke' && env.GOOGLE_PROJECT != '') || (matrix.envPlatform == 'eks' && env.AWS_ACCESS_KEY_ID != '') }}
         run: |
           SMOKE_ENV_TYPE=${{ matrix.envPlatform }} make run
       - name: make cleanup-kubernetes

--- a/test/cfg/kong-mesh-eks.yaml
+++ b/test/cfg/kong-mesh-eks.yaml
@@ -1,0 +1,12 @@
+helmChartName: kong-mesh/kong-mesh
+helmRepoUrl: https://kong.github.io/kong-mesh-charts
+helmChartPath: "."
+helmSubChartPrefix: kuma.
+imageRegistry: kong
+namespace: kong-mesh-system
+serviceName: kong-mesh-control-plane
+defaultClusterStartupRetries: 60 # bump this value because fetching containers may take more time than usual
+CNIConf:
+  BinDir: /opt/cni/bin
+  NetDir: /etc/cni/net.d
+  ConfName: 10-aws.conflist

--- a/test/cfg/kuma-eks.yaml
+++ b/test/cfg/kuma-eks.yaml
@@ -1,0 +1,12 @@
+helmChartName: kuma/kuma
+helmRepoUrl: https://kumahq.github.io/charts
+helmChartPath: "."
+helmSubChartPrefix:
+imageRegistry: kumahq
+namespace: kuma-system
+serviceName: kuma-control-plane
+defaultClusterStartupRetries: 60 # bump this value because fetching containers may take more time than usual
+CNIConf:
+  BinDir: /opt/cni/bin
+  NetDir: /etc/cni/net.d
+  ConfName: 10-aws.conflist


### PR DESCRIPTION
enable eks in CI workflow

We need to set correct credential to enable running on EKS clusters

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
* Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
* Yes