### PR TITLE
chore(workflow): allow concurrent running the smoke workflow

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,8 +1,5 @@
 name: Smoke
 run-name: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || (github.event_name == 'push' && github.event.head_commit.message || format( 'smoke test on {0} {1}', (inputs.product_name || 'kuma'), (inputs.product_version || ''))) }}
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request: {}
   push:


### PR DESCRIPTION
allow concurrent running the smoke workflow

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
* Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
* Yes